### PR TITLE
Update hero assets and social links

### DIFF
--- a/app/components/Contact.tsx
+++ b/app/components/Contact.tsx
@@ -4,7 +4,8 @@ import Link from "next/link";
 import { Input } from '@mui/base/Input';
 import { Button } from '@mui/base/Button';
 import { TextareaAutosize } from '@mui/base/TextareaAutosize';
-import { FaLinkedin, FaGithub } from "react-icons/fa";
+import { FaLinkedin, FaGithub, FaInstagram } from "react-icons/fa";
+import { GiCricketBat } from "react-icons/gi";
 
 export default function Contact() {
   const [name, setName] = useState('')
@@ -105,6 +106,17 @@ export default function Contact() {
                 {submitting ? 'Sending…' : 'Send'}
               </Button>
             </form>
+            <p className="text-center text-sm text-white/80">
+              Prefer a quick overview?{" "}
+              <Link
+                href="/assets/cv.pdf"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[#13adc7] hover:underline"
+              >
+                Download my CV
+              </Link>
+            </p>
           </div>
         </div>
       </div>
@@ -132,11 +144,21 @@ export default function Contact() {
             <a href="tel:+919151381254" className="hover:text-[#13adc7]">+91 91513 81254</a>
           </div>
           <div className="flex gap-6">
-            <Link href={"https://www.linkedin.com/in/karloshyadav/"} aria-label="Karlosh on LinkedIn">
+            <Link href={"https://www.linkedin.com/in/karloshyadav/"} aria-label="Karlosh on LinkedIn" target="_blank">
               <FaLinkedin className="md:w-7 md:h-7 w-6 h-6 text-white" />
             </Link>
-            <Link href={"https://github.com/karloshyadav"} aria-label="Karlosh on GitHub">
+            <Link href={"https://github.com/karloshyadav"} aria-label="Karlosh on GitHub" target="_blank">
               <FaGithub className="md:w-7 md:h-7 w-6 h-6 text-white" />
+            </Link>
+            <Link href={"https://www.instagram.com/karloshyadav/"} aria-label="Karlosh on Instagram" target="_blank">
+              <FaInstagram className="md:w-7 md:h-7 w-6 h-6 text-white" />
+            </Link>
+            <Link
+              href={"https://cricheroes.com/player-profile/9928702/karlosh-yadav/matches"}
+              aria-label="Karlosh on CricHeroes"
+              target="_blank"
+            >
+              <GiCricketBat className="md:w-7 md:h-7 w-6 h-6 text-white" />
             </Link>
           </div>
         </div>

--- a/app/components/Hero.tsx
+++ b/app/components/Hero.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 
 const RESUME_URL =
   process.env.NEXT_PUBLIC_RESUME_URL ??
-  "https://www.linkedin.com/in/karloshyadav/details/featured/";
+  "/assets/cv.pdf";
 
 export default function Hero() {
   return (
@@ -63,11 +63,37 @@ export default function Hero() {
               >
                 GitHub
               </Link>
+              <Link
+                href="https://www.instagram.com/karloshyadav/"
+                className="px-5 py-3 rounded-lg bg-white/10 text-white hover:bg-white/20 transition"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Instagram
+              </Link>
+              <Link
+                href="https://cricheroes.com/player-profile/9928702/karlosh-yadav/matches"
+                className="px-5 py-3 rounded-lg bg-white/10 text-white hover:bg-white/20 transition"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                CricHeroes
+              </Link>
             </div>
           </div>
         </div>
 
         <div className="container-profile lg:mb-0 md:mb-12">
+          <div className="absolute inset-0 -z-10 hidden lg:block pointer-events-none">
+            <Image
+              src="/assets/bg_1.png"
+              alt="Abstract gradient backdrop"
+              fill
+              className="object-contain opacity-20"
+              sizes="(min-width: 1024px) 640px"
+              priority
+            />
+          </div>
           <div className="profile-glow-2"></div>
           <div className="profile-glow"></div>
 
@@ -80,7 +106,7 @@ export default function Hero() {
             <div className="relative overflow-hidden rounded-full ring-1 ring-white/10 shadow-[0_40px_100px_-23px_#13adc7] bg-[#0f1624]
                             w-64 h-64 md:w-80 md:h-80 lg:w-[600px] lg:h-[600px]">
               <Image
-                src="/assets/profile.jpg"
+                src="/assets/profile.png"
                 alt="Karlosh Yadav"
                 fill
                 className="object-cover"

--- a/app/components/NavBar.tsx
+++ b/app/components/NavBar.tsx
@@ -3,7 +3,8 @@ import Link from "next/link";
 import { Link as ScrollLink } from "react-scroll";
 import { useState } from "react";
 import React from "react";
-import { FaLinkedin, FaGithub } from "react-icons/fa";
+import { FaLinkedin, FaGithub, FaInstagram } from "react-icons/fa";
+import { GiCricketBat } from "react-icons/gi";
 import { FaBars, FaTimes } from "react-icons/fa";
 
 export default function NavBar() {
@@ -65,11 +66,21 @@ export default function NavBar() {
           </ScrollLink>
         </div>
         <div className="flex gap-8 items-center   justify-center  md:order-3 order-2">
-          <Link href={"https://www.linkedin.com/in/karloshyadav/"} target="_blank">
+          <Link href={"https://www.linkedin.com/in/karloshyadav/"} target="_blank" aria-label="Karlosh on LinkedIn">
             <FaLinkedin className="md:w-7 w-6 h-6 md:h-7 text-white" />
           </Link>
-          <Link href={"https://github.com/karloshyadav"} target="_blank">
+          <Link href={"https://github.com/karloshyadav"} target="_blank" aria-label="Karlosh on GitHub">
             <FaGithub className="md:w-7 md:h-7 w-6 h-6  text-white" />
+          </Link>
+          <Link href={"https://www.instagram.com/karloshyadav/"} target="_blank" aria-label="Karlosh on Instagram">
+            <FaInstagram className="md:w-7 md:h-7 w-6 h-6 text-white" />
+          </Link>
+          <Link
+            href={"https://cricheroes.com/player-profile/9928702/karlosh-yadav/matches"}
+            target="_blank"
+            aria-label="Karlosh on CricHeroes"
+          >
+            <GiCricketBat className="md:w-7 md:h-7 w-6 h-6 text-white" />
           </Link>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- point the résumé button and contact callout to the hosted CV asset
- show the hero portrait/background from the assets folder and expand its social link list
- surface Instagram and CricHeroes icons in the navigation bar and contact footer

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7e17053b8833387fd867cec85f0a0