### PR TITLE
Add faded IISc image as background

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -29,6 +29,12 @@ html {
   scroll-behavior: smooth;
 }
 
+body {
+  min-height: 100vh;
+  background: linear-gradient(rgba(15, 22, 36, 0.88), rgba(15, 22, 36, 0.88)),
+    url("/assets/iisc.jpeg") center/cover no-repeat fixed;
+}
+
 .cursor {
   position: fixed;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- layer the IISc campus image behind the site with a darkened overlay so it spans the entire viewport

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7f3b0e45083339984c6533635d1fd